### PR TITLE
ci: add migration and seeding steps to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
         run: composer lint
       - name: Static Analysis (PHPStan)
         run: composer stan
+      - name: Run Migrations
+        env:
+          APP_ENV: testing
+        run: php artisan migrate --env=testing --force
+      - name: Seed database
+        env:
+          APP_ENV: testing
+          SEED_PROFILE: mini
+        run: php artisan db:seed --env=testing --force
       - name: Test (PHPUnit)
         env:
           APP_ENV: testing


### PR DESCRIPTION
- Run `php artisan migrate --env=testing --force` during CI
- Added optional seeding step (MiniSeeder via SEED_PROFILE=mini)
- Ensure SQLite testing database is migrated before running tests