### PR TITLE
test: add soft delete tests for User, Project, Task, TaskComment, Label

### DIFF
--- a/tests/Feature/Models/SoftDeletesTest.php
+++ b/tests/Feature/Models/SoftDeletesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Label;
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\TaskComment;
+use App\Models\User;
+
+dataset('softDeletableModels', [
+    [User::class, fn () => User::factory()->create()],
+    [Project::class, fn () => Project::factory()->create()],
+    [Task::class, fn () => Task::factory()->create()],
+    [TaskComment::class, fn () => TaskComment::factory()->create()],
+    [Label::class, fn () => Label::factory()->create()],
+]);
+
+it('soft deletes and restores', function (string $class, Closure $make) {
+    $model = $make();
+    $id    = $model->getKey();
+
+    $model->delete();
+    expect($class::query()->find($id))->toBeNull();
+
+    $trashed = $class::query()->withTrashed()->find($id);
+    expect($trashed)->not->toBeNull()
+        ->and($trashed->deleted_at)->not->toBeNull();
+
+    $trashed->restore();
+    expect($class::query()->find($id))->not->toBeNull();
+})->with('softDeletableModels');


### PR DESCRIPTION
### Changes
- Added dataset `softDeletableModels` for reusable test coverage
- Implemented `soft deletes and restores` test:
  - Verifies `delete()` hides record from default query
  - Confirms `withTrashed()` can retrieve soft-deleted records
  - Ensures `restore()` recovers the model
- Covered models:
  - User
  - Project
  - Task
  - TaskComment
  - Label