### PR TITLE
Add project/task policies and middleware with role-based authorization tests

### DIFF
--- a/app/Http/Middleware/EnsureProjectMember.php
+++ b/app/Http/Middleware/EnsureProjectMember.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Project;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureProjectMember
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user    = $request->user();
+        $project = $request->route('project');
+
+        if (! $project instanceof Project) {
+            abort(404);
+        }
+
+        $isMember = $project->projectMembers()
+            ->where('user_id', $user->id)
+            ->exists();
+
+        if (! $isMember && $project->owner_id !== $user->id) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\ProjectRole;
+use App\Models\Project;
+use App\Models\User;
+use App\Support\ProjectAcl;
+
+class ProjectPolicy
+{
+    public function view(User $user, Project $project): bool
+    {
+        return $project->owner_id === $user->id
+            || $project->projectMembers()->where('user_id', $user->id)->exists();
+    }
+
+    public function update(User $user, Project $project): bool
+    {
+        $role = ProjectAcl::roleOf($project, $user);
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin], true);
+    }
+
+    public function delete(User $user, Project $project): bool
+    {
+        return ProjectAcl::roleOf($project, $user) === ProjectRole::Owner;
+    }
+
+    public function manageMembers(User $user, Project $project): bool
+    {
+        $role = ProjectAcl::roleOf($project, $user);
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin], true);
+    }
+
+    public function transferOwnership(User $user, Project $project): bool
+    {
+        return ProjectAcl::roleOf($project, $user) === ProjectRole::Owner;
+    }
+}

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\ProjectRole;
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\User;
+use App\Support\ProjectAcl;
+
+class TaskPolicy
+{
+    public function view(User $user, Task $task): bool
+    {
+        $project = $task->project;
+
+        return $project && ($project->owner_id === $user->id || $project->projectMembers()->where('user_id', $user->id)->exists());
+    }
+
+    public function create(User $user, Project $project): bool
+    {
+        $role = ProjectAcl::roleOf($project, $user);
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin, ProjectRole::Member], true);
+    }
+
+    public function update(User $user, Task $task): bool
+    {
+        $project = $task->project;
+        $role    = $project ? ProjectAcl::roleOf($project, $user) : null;
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin])
+            || $task->creator_id  === $user->id
+            || $task->assignee_id === $user->id;
+    }
+
+    public function delete(User $user, Task $task): bool
+    {
+        $project = $task->project;
+        $role    = $project ? ProjectAcl::roleOf($project, $user) : null;
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin])
+            || $task->creator_id === $user->id;
+    }
+
+    public function assign(User $user, Task $task): bool
+    {
+        $project = $task->project;
+        $role    = $project ? ProjectAcl::roleOf($project, $user) : null;
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin]);
+    }
+
+    public function claim(User $user, Task $task): bool
+    {
+        if ($task->assignee_id !== null) {
+            return false;
+        }
+
+        $project = $task->project;
+        $role    = $project ? ProjectAcl::roleOf($project, $user) : null;
+
+        return in_array($role, [ProjectRole::Owner, ProjectRole::Admin, ProjectRole::Member]);
+    }
+
+    public function comment(User $user, Task $task): bool
+    {
+        return $this->view($user, $task);
+    }
+
+    public function label(User $user, Task $task): bool
+    {
+        return $this->view($user, $task);
+    }
+}

--- a/app/Support/ProjectAcl.php
+++ b/app/Support/ProjectAcl.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Support;
+
+use App\Enums\ProjectRole;
+use App\Models\Project;
+use App\Models\User;
+
+class ProjectAcl
+{
+    public static function roleOf(Project $project, User $user): ?ProjectRole
+    {
+        if ($project->owner_id === $user->id) {
+            return ProjectRole::Owner;
+        }
+        $projectMember = $project->projectMembers()->where('user_id', $user->id)->first();
+
+        return $projectMember?->role;
+    }
+
+    public static function atLeast(ProjectRole $role, ProjectRole $min): bool
+    {
+        $rank = [
+            ProjectRole::Viewer->value => 1,
+            ProjectRole::Member->value => 2,
+            ProjectRole::Admin->value  => 3,
+            ProjectRole::Owner->value  => 4,
+        ];
+
+        return $rank[$role->value] >= $rank[$min->value];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'project.member' => \App\Http\Middleware\EnsureProjectMember::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/tests/Feature/Auth/ProjectPolicyTest.php
+++ b/tests/Feature/Auth/ProjectPolicyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Support\Facades\Gate;
+
+it('project view: denies outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+
+    expect(Gate::forUser($outsider)->denies('view', $project))->toBeTrue()
+        ->and(Gate::forUser($owner)->allows('view', $project))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('view', $project))->toBeTrue()
+        ->and(Gate::forUser($member)->allows('view', $project))->toBeTrue()
+        ->and(Gate::forUser($viewer)->allows('view', $project))->toBeTrue();
+
+});
+
+it('project update: allows owner/admin, denies member/viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+
+    expect(Gate::forUser($owner)->allows('update', $project))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('update', $project))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('update', $project))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('update', $project))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('update', $project))->toBeTrue();
+});
+
+it('project delete: only owner', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+
+    expect(Gate::forUser($owner)->allows('delete', $project))->toBeTrue()
+        ->and(Gate::forUser($admin)->denies('delete', $project))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('delete', $project))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('delete', $project))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('delete', $project))->toBeTrue();
+});
+
+it('project manageMembers: allows owner/admin, denies member/viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+
+    expect(Gate::forUser($owner)->allows('manageMembers', $project))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('manageMembers', $project))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('manageMembers', $project))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('manageMembers', $project))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('manageMembers', $project))->toBeTrue();
+});
+
+it('project transferOwnership: only owner', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+
+    expect(Gate::forUser($owner)->allows('transferOwnership', $project))->toBeTrue()
+        ->and(Gate::forUser($admin)->denies('transferOwnership', $project))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('transferOwnership', $project))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('transferOwnership', $project))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('transferOwnership', $project))->toBeTrue();
+});

--- a/tests/Feature/Auth/TaskPolicyTest.php
+++ b/tests/Feature/Auth/TaskPolicyTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Enums\ProjectRole;
+use App\Models\ProjectMember;
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+it('task view, denies outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $task                                                                                                                            = Task::factory()->for($project)->for($owner, 'creator')->create();
+
+    expect(Gate::forUser($outsider)->denies('view', $task))->toBeTrue()
+        ->and(Gate::forUser($owner)->allows('view', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('view', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->allows('view', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->allows('view', $task))->toBeTrue();
+});
+
+it('task create, allows owner/admin, denies member/viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+
+    expect(Gate::forUser($owner)->allows('create', [Task::class, $project]))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('create', [Task::class, $project]))->toBeTrue()
+        ->and(Gate::forUser($member)->allows('create', [Task::class, $project]))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('create', [Task::class, $project]))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('create', [Task::class, $project]))->toBeTrue();
+});
+
+it('task update, allows owner/admin/task_creator/task_assignee, denies member/viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $creator                                                                                                                         = User::factory()->create();
+    $assignee                                                                                                                        = User::factory()->create();
+
+    ProjectMember::factory()->for($project)->for($creator)->create(['role' => ProjectRole::Member]);
+    ProjectMember::factory()->for($project)->for($assignee)->create(['role' => ProjectRole::Member]);
+
+    $task = Task::factory()->for($project)->for($creator, 'creator')->for($assignee, 'assignee')->create();
+
+    expect(Gate::forUser($owner)->allows('update', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('update', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('update', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('update', $task))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('update', $task))->toBeTrue()
+        ->and(Gate::forUser($creator)->allows('update', $task))->toBeTrue()
+        ->and(Gate::forUser($assignee)->allows('update', $task))->toBeTrue();
+
+});
+
+it('task delete, allows owner/admin/task_creator, denies member/viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $creator                                                                                                                         = User::factory()->create();
+
+    ProjectMember::factory()->for($project)->for($creator)->create(['role' => ProjectRole::Member]);
+
+    $task = Task::factory()->for($project)->for($creator, 'creator')->create();
+
+    expect(Gate::forUser($owner)->allows('delete', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('delete', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('delete', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('delete', $task))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('delete', $task))->toBeTrue()
+        ->and(Gate::forUser($creator)->allows('delete', $task))->toBeTrue();
+});
+
+it('task assign, allows owner/admin, denies member/viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $task                                                                                                                            = Task::factory()->for($project)->for($owner, 'creator')->create();
+
+    expect(Gate::forUser($owner)->allows('assign', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('assign', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('assign', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('assign', $task))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('assign', $task))->toBeTrue();
+});
+
+it('task claim, allows owner/admin/member claim with non-assignee task, denies viewer/outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $task                                                                                                                            = Task::factory()->for($project)->for($owner, 'creator')->create();
+
+    expect(Gate::forUser($owner)->allows('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->allows('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('claim', $task))->toBeTrue();
+
+    $assignee = User::factory()->create();
+    ProjectMember::factory()->for($project)->for($assignee)->create(['role' => ProjectRole::Member]);
+    $task->forceFill(['assignee_id' => $assignee->id])->save();
+
+    expect(Gate::forUser($owner)->denies('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->denies('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->denies('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->denies('claim', $task))->toBeTrue()
+        ->and(Gate::forUser($outsider)->denies('claim', $task))->toBeTrue();
+});
+
+it('task comment, denies outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $task                                                                                                                            = Task::factory()->for($project)->for($owner, 'creator')->create();
+
+    expect(Gate::forUser($outsider)->denies('comment', $task))->toBeTrue()
+        ->and(Gate::forUser($owner)->allows('comment', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('comment', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->allows('comment', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->allows('comment', $task))->toBeTrue();
+});
+
+it('task label, denies outsider', function () {
+    ['project' => $project, 'owner' => $owner, 'admin' => $admin, 'member' => $member, 'viewer' => $viewer, 'outsider' => $outsider] = setupProjectWithRoles();
+    $task                                                                                                                            = Task::factory()->for($project)->for($owner, 'creator')->create();
+
+    expect(Gate::forUser($outsider)->denies('label', $task))->toBeTrue()
+        ->and(Gate::forUser($owner)->allows('label', $task))->toBeTrue()
+        ->and(Gate::forUser($admin)->allows('label', $task))->toBeTrue()
+        ->and(Gate::forUser($member)->allows('label', $task))->toBeTrue()
+        ->and(Gate::forUser($viewer)->allows('label', $task))->toBeTrue();
+});

--- a/tests/Feature/Middleware/EnsureProjectMemberTest.php
+++ b/tests/Feature/Middleware/EnsureProjectMemberTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/** @var TestCase $this */
+
+use App\Enums\ProjectRole;
+use App\Models\Project;
+use App\Models\ProjectMember;
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+
+use function Pest\Laravel\actingAs;
+
+use Tests\TestCase;
+
+beforeEach(function () {
+    Route::middleware(['web', 'project.member'])
+        ->get('/_t/project/{project}/ping', fn (Project $project) => response()->json(['ok' => true]));
+});
+
+it('non-bind project (404)', function () {
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->getJson('/_t/project/999999/ping')
+        ->assertNotFound();
+});
+
+it('blocks non-member (403)', function () {
+    $owner    = User::factory()->create();
+    $outsider = User::factory()->create();
+    $project  = Project::factory()->for($owner, 'owner')->create();
+
+    actingAs($outsider)
+        ->getJson("/_t/project/{$project->id}/ping")
+        ->assertForbidden();
+});
+
+it('allow member (200)', function () {
+    $owner   = User::factory()->create();
+    $member  = User::factory()->create();
+    $project = Project::factory()->for($owner, 'owner')->create();
+
+    ProjectMember::factory()
+        ->for($project)
+        ->for($member)
+        ->create([
+            'role' => ProjectRole::Member,
+        ]);
+
+    actingAs($member)
+        ->getJson("/_t/project/{$project->id}/ping")
+        ->assertOk()
+        ->assertJson(['ok' => true]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,35 @@
 <?php
 
+use App\Enums\ProjectRole;
+use App\Models\Project;
+use App\Models\ProjectMember;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(Tests\TestCase::class)->in('Feature', 'Unit');
 uses(RefreshDatabase::class)->in('Feature');
+
+/**
+ * @return array{
+ *   project: Project,
+ *   owner: User,
+ *   admin: User,
+ *   member: User,
+ *   viewer: User,
+ *   outsider: User }
+ */
+function setupProjectWithRoles(): array
+{
+    $owner    = User::factory()->create();
+    $admin    = User::factory()->create();
+    $member   = User::factory()->create();
+    $viewer   = User::factory()->create();
+    $outsider = User::factory()->create();
+    $project  = Project::factory()->for($owner, 'owner')->create();
+
+    ProjectMember::factory()->for($project)->for($admin)->create(['role' => ProjectRole::Admin]);
+    ProjectMember::factory()->for($project)->for($member)->create(['role' => ProjectRole::Member]);
+    ProjectMember::factory()->for($project)->for($viewer)->create(['role' => ProjectRole::Viewer]);
+
+    return compact('project', 'owner', 'admin', 'member', 'viewer', 'outsider');
+}


### PR DESCRIPTION
### Summary
This PR introduces the first iteration of authorization layer (iteration 2: policies & middleware).

### Changes
- **Middleware**
  - Added `EnsureProjectMember` middleware to enforce project membership
  - Registered middleware alias in `bootstrap/app.php`
  - Added feature test `EnsureProjectMemberTest`

- **Policies**
  - Added `ProjectPolicy` with role-based rules for view, update, delete, manageMembers, transferOwnerShip
  - Added `TaskPolicy` with rules for view, create, update, delete, assign, claim, comment, label
  - Added support class `ProjectAcl` to centralize role lookup
  - Added feature tests `ProjectPolicyTest` and `TaskPolicyTest`

- **Test setup**
  - Added helper in `tests/Pest.php` for common project+roles setup
  - Ensured middleware and policy behavior are covered across roles (owner, admin, member, viewer, outsider, plus task creator/assignee)

### Motivation
- Before: no centralized authorization rules, middleware untested
- Now: complete role-based authorization layer for projects and tasks
  - Middleware ensures membership at routing layer
  - Policies enforce granular permissions
  - Tests guarantee consistency for all roles