### PR TITLE
ci: add GitHub Actions deploy workflow (manual ssh deployment)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to Server
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: 22
+          script: |
+            cd /var/www/task-manager
+            ./deploy.sh


### PR DESCRIPTION
# PR Summary
Add a GitHub Actions deploy workflow (`deploy.yml`) to support manual SSH-based deployment to the server.

---

## Changes
- Added `.github/workflows/deploy.yml` workflow
- Configured manual `workflow_dispatch` trigger
- Added SSH deployment step using `appleboy/ssh-action`
- Integrated remote execution of `deploy.sh` on server

---

## Type of Change
- [ ] Feature
- [ ] Fix
- [ ] Docs
- [ ] Refactor
- [x] CI
- [ ] Other
